### PR TITLE
Updated fast qr filter

### DIFF
--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -98,7 +98,7 @@ void ResidualSumPreconditioner::_update_(bool                   timestepComplete
           } 
         //}
       normWeights[k] = 1 / _residualSum[k];
-      PRECICE_INFO("Actual Norm of weights: " << _weights[1 + offset]);
+      PRECICE_INFO("Actual Norm of weights: " << _setWeights[k]);
       PRECICE_INFO("Predicted Norm of weights: " << normWeights[k]);
       offset += _subVectorSizes[k];
       //PRECICE_INFO("Norm of weights: first " << firstWeight << " and Second: " << secondWeight);

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -32,6 +32,7 @@ public:
 
   int tStepPrecon = 1;
   Eigen::VectorXd normWeights;
+  
 
 
 private:
@@ -45,6 +46,7 @@ private:
   logging::Logger _log{"acceleration::ResidualSumPreconditioner"};
 
   std::vector<double> _residualSum;
+  std::vector<double> _setWeights;
 };
 
 } // namespace impl


### PR DESCRIPTION
## Main changes of this PR
Allows an arbitrary number of coupling data vectors to be used in the preconditioner

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I added a changelog file with this PR number in `docs/changelog/` if there are noteworthy changes.
* [ ] I ran `tools/formatting/check-format` and everything is formatted correctly.
* [ ] I sticked to C++14 features.
* [ ] I sticked to CMake version 3.10.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
* [ ] (more questions/tasks)